### PR TITLE
Make reclineview work with GET requests again

### DIFF
--- a/ckanext/reclineview/theme/public/vendor/ckan.js/ckan.js
+++ b/ckanext/reclineview/theme/public/vendor/ckan.js/ckan.js
@@ -22,7 +22,7 @@ if (isNodeModule) {
     var options = {
       url: this.endpoint + '/3/action/' + name,
       data: data,
-      type: 'POST'
+      type: 'GET'
     };
     return this._ajax(options, cb);
   };
@@ -119,7 +119,7 @@ if (isNodeModule) {
 
   var _browserRequest = function(options, cb) {
     var self = this;
-    options.data = encodeURIComponent(JSON.stringify(options.data));
+    //options.data = encodeURIComponent(JSON.stringify(options.data));
     options.success = function(data) {
       cb(null, data);
     }


### PR DESCRIPTION
The city of Zurich portal doesn't allow any other requests than GET and
therefore recline view needs to be updated to get it's data in a
different way. The datastore_search API works with GET and POST so there
is no problem in changing the method.

With GET there is no need to stringify the data JSON.