### PR TITLE
Deprecate the url() helper and use url_for() instead

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -133,11 +133,10 @@ def redirect_to(*args, **kw):
 
 
 def url(*args, **kw):
-    '''Create url adding i18n information if selected
-    wrapper for pylons.url'''
-    locale = kw.pop('locale', None)
-    my_url = _pylons_default_url(*args, **kw)
-    return _add_i18n_to_url(my_url, locale=locale, **kw)
+    '''
+    Deprecated: please use `url_for` instead
+    '''
+    return url_for(*args, **kw)
 
 
 def get_site_protocol_and_host():

--- a/ckan/templates/package/snippets/resource_view.html
+++ b/ckan/templates/package/snippets/resource_view.html
@@ -6,7 +6,7 @@
        href="#embed-{{ resource_view['id'] }}"
        data-module="resource-view-embed"
        data-module-id="{{ resource_view['id'] }}"
-       data-module-url="{{ h.url('resource_view', id=package['name'], resource_id=resource['id'], view_id=resource_view['id'], qualified=True) }}">
+       data-module-url="{{ h.url_for('resource_view', id=package['name'], resource_id=resource['id'], view_id=resource_view['id'], qualified=True) }}">
       <i class="icon-code"></i>
       {{ _("Embed") }}
     </a>
@@ -37,20 +37,20 @@
         {% if not to_preview %}
           {% set current_filters = request.str_GET.get('filters') %}
           {% if current_filters %}
-            {% set src = h.url(qualified=true, controller='package',
+            {% set src = h.url_for(qualified=true, controller='package',
                                action='resource_view', id=package['name'],
                                resource_id=resource['id'],
                                view_id=resource_view['id'],
                                filters=current_filters)  %}
           {% else %}
-            {% set src = h.url(qualified=true, controller='package',
+            {% set src = h.url_for(qualified=true, controller='package',
                                action='resource_view', id=package['name'],
                                resource_id=resource['id'],
                                view_id=resource_view['id'])  %}
           {% endif %}
         {% else %}
           {# When previewing we need to stick the whole resource_view as a param as there is no other way to pass to information on to the iframe #}
-          {% set src = h.url(qualified=true, controller='package', action='resource_view', id=package['name'], resource_id=resource['id']) + '?' + h.urlencode({'resource_view': h.dump_json(resource_view)}) %}
+          {% set src = h.url_for(qualified=true, controller='package', action='resource_view', id=package['name'], resource_id=resource['id']) + '?' + h.urlencode({'resource_view': h.dump_json(resource_view)}) %}
         {% endif %}
         <iframe src="{{ src }}" frameborder="0" width="100%" data-module="data-viewer">
           <p>{{ _('Your browser does not support iframes.') }}</p>


### PR DESCRIPTION
This is an adaption of the CKAN commit
https://github.com/ckan/ckan/commit/1df9543ac1585e46f59b4fd73f20a7a80877c5b7

url_for makes sure, that a full qualified URL is based on the configured
site_url.